### PR TITLE
Add renderer argument to JSONEditor.render() method

### DIFF
--- a/jsoneditor/forms.py
+++ b/jsoneditor/forms.py
@@ -37,7 +37,7 @@ class JSONEditor(Textarea):
         )
         css= {'all': ( getattr(settings, "JSON_EDITOR_CSS",settings.STATIC_URL+'jsoneditor/jsoneditor.css'),)}
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if not isinstance(value,basestring):
            value = json.dumps(value)
         input_attrs = {'hidden':True}


### PR DESCRIPTION
Fixes #36

This argument becomes required to use Django 2.1. The argument is added at the end and is optional, so that it remains backwards compatible with earlier version of Django.