### PR TITLE
Fix for Django 2.0

### DIFF
--- a/jsoneditor/forms.py
+++ b/jsoneditor/forms.py
@@ -1,17 +1,17 @@
+import json
 from packaging import version
-import django
 
+import django
+from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.conf import settings
 from django.forms.widgets import Textarea
+from django.utils.safestring import mark_safe
+
+
 try:
     from django.forms.util import flatatt
 except ImportError:
     from django.forms.utils import flatatt
-
-from django.utils.safestring import mark_safe
-
-from django.conf import settings
-
-import json
 
 try:
     unicode = unicode
@@ -20,7 +20,7 @@ except NameError:
     str = str
     unicode = str
     bytes = bytes
-    basestring = (str,bytes)
+    basestring = (str, bytes)
 else:
     # 'unicode' exists, must be Python 2
     str = str
@@ -32,31 +32,34 @@ else:
 class JSONEditor(Textarea):
     class Media:
         js = (
-            getattr(settings,"JSON_EDITOR_JS",settings.STATIC_URL+'jsoneditor/jsoneditor.js'),
-            settings.STATIC_URL+'django-jsoneditor/django-jsoneditor.js',
+            static('admin/js/vendor/jquery/jquery.js'),
+            static('admin/js/jquery.init.js'),
+            getattr(settings, "JSON_EDITOR_JS", static('jsoneditor/jsoneditor.js')),
+            static('django-jsoneditor/django-jsoneditor.js'),
         )
-        css= {'all': ( getattr(settings, "JSON_EDITOR_CSS",settings.STATIC_URL+'jsoneditor/jsoneditor.css'),)}
+        css = {'all': (getattr(settings, "JSON_EDITOR_CSS", settings.STATIC_URL + 'jsoneditor/jsoneditor.css'),)}
+
 
     def render(self, name, value, attrs=None, renderer=None):
-        if not isinstance(value,basestring):
-           value = json.dumps(value)
-        input_attrs = {'hidden':True}
+        if not isinstance(value, basestring):
+            value = json.dumps(value)
+        input_attrs = {'hidden': True}
         input_attrs.update(attrs)
-        if not 'class' in input_attrs:
+        if 'class' not in input_attrs:
             input_attrs['class'] = 'for_jsoneditor'
         else:
             input_attrs['class'] += ' for_jsoneditor'
-        r = super(JSONEditor,self).render(name, value, input_attrs)
+        r = super(JSONEditor, self).render(name, value, input_attrs)
         div_attrs = {}
         div_attrs.update(attrs)
-        div_attrs.update({'id':(attrs['id']+'_jsoneditor')})
+        div_attrs.update({'id': (attrs['id'] + '_jsoneditor')})
         if version.parse(django.get_version()) >= version.parse("1.11"):
-            final_attrs = self.build_attrs(div_attrs, extra_attrs={'name':name})
+            final_attrs = self.build_attrs(div_attrs, extra_attrs={'name': name})
         else:
             final_attrs = self.build_attrs(div_attrs, name=name)
         r += '''
         <div %(attrs)s></div>
         ''' % {
-            'attrs':flatatt(final_attrs),
+            'attrs': flatatt(final_attrs),
         }
         return mark_safe(r)


### PR DESCRIPTION
I found the reason why the package is not working in Django 2.0 - jQuery is added after jsoneditor, preventing the package from initializing successfully. 

My approach to solving this issue is to add jquery code before injecting jsoneditor. Sadly it's not perfect, because jquery is injected twice to `<head>`, but it works with Django 2.0. I need someone to test if it's still working correctly with Django 1.x, but I believe it should. Another approach that also could be working is to add some kind of `ready()` function that waits until the document is loaded (eg. https://stackoverflow.com/a/7053197).

Also, I've made `forms.py` PEP8 compliant.

Closes #39 