### PR TITLE
Allow any editor value to be sent to a Django server, even invalid JSON

### DIFF
--- a/jsoneditor/static/django-jsoneditor/django-jsoneditor.js
+++ b/jsoneditor/static/django-jsoneditor/django-jsoneditor.js
@@ -31,15 +31,16 @@ django.jQuery(function () {
                     }
                 }, django_jsoneditor_init));
 
-                // Force editor mode to "code" if there are JSON parse errors.
+                // Load the editor.
                 try {
-                    JSON.parse(value);
+                    editor.set(JSON.parse(value));
                 } catch (e) {
+                    // Force editor mode to "code" if there are JSON parse errors.
                     editor.setMode('code');
-                }
 
-                // Initialise contents of form even on unparseable JSON on load
-                editor.setText(value);
+                    // Initialise contents of form even on unparseable JSON on load
+                    editor.setText(value);
+                }
 
                 // If initialized in code mode, set ace options right away
                 if (editor.mode == 'code') {

--- a/jsoneditor/static/django-jsoneditor/django-jsoneditor.js
+++ b/jsoneditor/static/django-jsoneditor/django-jsoneditor.js
@@ -13,19 +13,15 @@ django.jQuery(function () {
             if ($nxt.attr("name") == name) {
                 continue;
             }
-            var value = {};
-            try {
-                value = JSON.parse($f[0].value);
-            } catch (e) {
-                // ignore
-            }
+            var value = $f[0].value;
+
             $nxt.detach();
             $nxt = django.jQuery('<div class="outer_jsoneditor" cols="40" rows="10" id="' + id + '" name="' + name + '"></div>');
             $f.parent().append($nxt);
             var fnc = function (f, nxt, value) {
                 var editor = new jsoneditor.JSONEditor(nxt, Object.assign({
                     onChange: function () {
-                        f.value = JSON.stringify(editor.get());
+                        f.value = editor.getText();
                     },
                     // If switching to code mode, properly initialize with ace options
                     onModeChange: function(endMode, startMode) {
@@ -33,11 +29,24 @@ django.jQuery(function () {
                             editor.aceEditor.setOptions(django_jsoneditor_ace_options);
                         }
                     }
-                }, django_jsoneditor_init), value);
+                }, django_jsoneditor_init));
+
+                // Force editor mode to "code" if there are JSON parse errors.
+                try {
+                    JSON.parse(value);
+                } catch (e) {
+                    editor.setMode('code');
+                }
+
+                // Initialise contents of form even on unparseable JSON on load
+                editor.setText(value);
 
                 // If initialized in code mode, set ace options right away
                 if (editor.mode == 'code') {
                     editor.aceEditor.setOptions(django_jsoneditor_ace_options);
+
+                    // Format the code on first load
+                    editor.format();
                 }
 
                 return editor;


### PR DESCRIPTION
- The initialisation no longer uses a parsed JSON object.

The field can be invalid if the field was not valid JSON which results in a `ValidationError`. This is desired and very possible especially with non-technical users of the Django admin.

- Initialisation of content uses `setText` rather than the constructor for `JSONEditor`.

This is good for two reasons: 1) text is handled by the dependency and not more local code and 2) invalid JSON can not be initialised to avoid data loss.

- If the view is initially the "code" view, run a format.

Because otherwise it won't run a format after loading in directly with `setText`.

Note that it is only possible to get invalid JSON if the user tries to send invalid JSON in the admin which is only possible if `code` is a potential mode (or the user fiddles with the DOM). Both of these cases are edge cases that I don't believe need to be solved by this PR, but in the case that it does, forcing the mode to `code` on invalid `JSON.parse` will do the trick.

Closes #50.