### PR TITLE
Use standard django3 JSONField

### DIFF
--- a/jsoneditor/fields/postgres_jsonfield.py
+++ b/jsoneditor/fields/postgres_jsonfield.py
@@ -1,5 +1,5 @@
-from django.contrib.postgres.fields import JSONField as _JSONField
-from django.contrib.postgres.forms import JSONField as _JSONFormField
+from django.db.models import JSONField as _JSONField
+from django.forms import JSONField as _JSONFormField
 
 from jsoneditor.forms import JSONEditor
 


### PR DESCRIPTION
Hello, this should remove the warnings stating that django.contrib.postgres.fields,JSONField is deprecated and will be removed from Django 4.

If you prefer, this could be wrapped in a `try - except` clause to provide backwards compatibility, importing the legacy version if the new one isn't available.