### PR TITLE
Using standard Django3 JSONField and JSONFormField

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,16 @@ Right now there are the following fixed implementations:
 * `jsoneditor.fields.postgres_jsonfield.JSONField` replaces `django.contrib.postgres.fields.JSONField` (**NOTE** this field type appears only from django v.1.9)
 * `jsoneditor.fields.django_extensions_jsonfield.JSONField` replaces `django_extensions.db.fields.json.JSONField`
 * `jsoneditor.fields.jsonfield` is now added for people using https://github.com/rpkilby/jsonfield
+* `jsoneditor.fields.django3_jsonfield` uses the standard JSONField and JSONFormField provided by Django 3+
 
-Use the fixed implementation instead of the original one like
+To use the fixed implementation instead of the original one, just replace your import with the desired one. For example, for Django 3.0 and above:
 
 models.py:
 ```python
 from django.db import models
 
 # from json_field import JSONField replaced by:
-from jsoneditor.fields.django_json_field import JSONField
+from jsoneditor.fields.django3_jsonfield import JSONField
 # Create your models here.
 
 class TestModel(models.Model):

--- a/jsoneditor/fields/django3_jsonfield.py
+++ b/jsoneditor/fields/django3_jsonfield.py
@@ -1,0 +1,18 @@
+from django.db.models import JSONField as _JSONField
+from django.forms import JSONField as _JSONFormField
+
+from jsoneditor.forms import JSONEditor
+
+class JSONFormField(_JSONFormField):
+    widget = JSONEditor
+    def __init__(self,*av,**kw):
+        kw['widget'] = self.widget # force avoiding widget override
+        super(JSONFormField,self).__init__(*av,**kw)
+
+class JSONField(_JSONField):
+    def formfield(self, **kwargs):
+        defaults = {
+            'form_class': kwargs.get('form_class', JSONFormField),
+        }
+        defaults.update(kwargs)
+        return super(JSONField, self).formfield(**defaults)


### PR DESCRIPTION
As agreed in #57, I've created a new JSONField submodule specific for Django 3 and above, and updated the documentation accordingly.

Kind regards,
Pietro