### PR TITLE
add custom style support

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ class MyAdmin(admin.ModelAdmin):
 
 ```
 
+## Custom Style
+
+You can pass the style in attrs params for `JSONEditor` widget so that
+jsoneditor render with the style what you setup. Example:
+
+``` python
+from json_field import JSONField
+from jsoneditor.forms import JSONEditor
+
+class MyAdmin(admin.ModelAdmin):
+    formfield_overrides = {
+        JSONField: {'widget': JSONEditor(attrs={'style': 'width: 620px;'})}
+    }
+```
 
 ## Collecting bounties
 

--- a/jsoneditor/static/django-jsoneditor/django-jsoneditor.js
+++ b/jsoneditor/static/django-jsoneditor/django-jsoneditor.js
@@ -14,11 +14,16 @@ django.jQuery(function () {
                 continue;
             }
             var value = $f[0].value;
+            var style = $f.attr("style");
             var disabled = $f.is(':disabled');
             var jsonschema = JSON.parse($f.attr("jsonschema"));
 
             $nxt.detach();
-            $nxt = django.jQuery('<div class="outer_jsoneditor" cols="40" rows="10" id="' + id + '" name="' + name + '"></div>');
+            if (style) {
+                $nxt = django.jQuery('<div class="outer_jsoneditor" cols="40" rows="10" style="' + style + '" id="' + id + '" name="' + name + '"></div>');
+            } else {
+                $nxt = django.jQuery('<div class="outer_jsoneditor" cols="40" rows="10" id="' + id + '" name="' + name + '"></div>');
+            }
             $f.parent().append($nxt);
             var fnc = function (f, nxt, value) {
                 var initOptions = Object.assign({}, django_jsoneditor_init);


### PR DESCRIPTION
custom style from attrs when using `JSONEditor`

```
# admin.py
class MyCustomAdmin(admin.ModelAdmin):
    formfield_overrides = {
        JSONField: {'widget': JSONEditor(attrs={'style': 'width: 620px;'})}
    }
```

in django admin
![image](https://user-images.githubusercontent.com/7899044/170175736-36f6ad0d-7863-4ca7-ae5e-f16e434361f7.png)

for #61 