### PR TITLE
Fixes issue #65: Allow overriding jsoneditor and ace editor options for individual fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Sample views:
 
 <img alt="json editor" src="https://raw.github.com/josdejong/jsoneditor/master/misc/jsoneditor.png">
 
-*Don't mismatch this repo with https://github.com/skyhood/django-jsoneditor*
-
 ## Installation
 
 ### Latest version from the GIT repository::
@@ -29,9 +27,9 @@ Note that you should use one of original JSONField packages to provide the JSONF
 You **should** append `jsoneditor` into the `INSTALLED_APPS` of your `settings.py` file:
 ```python
 INSTALLED_APPS = (
-    ...
+    # ...
     'jsoneditor',
-    ...
+    # ...
 )
 ```
 
@@ -59,7 +57,7 @@ file.
 **Note** that the django original static file subsystem is used to
 refer to the init file.
 
-For example, let's your project has a `myapp` application,
+For example, let's say your project has a `myapp` application,
 and you would like to init all available modes of the JSONEditor
 instead of two allowed by default.
 
@@ -77,7 +75,7 @@ JSON_EDITOR_INIT_JS = "jsoneditor-init.js"
 ```
 (**note** that the static file subsystem refers to static files without `static` prefix)
 
-Also you can extend the `JSON_EDITOR_INIT_JS` file as you wish, it will be used on every
+You can extend the `JSON_EDITOR_INIT_JS` file as you wish; it will be used on every
 page where the `JSONEditor` widget is used just before the `django-jsonfield.js` file.
 
 ### Custom Ace initialization
@@ -91,17 +89,44 @@ pointed to by adding the following line to your `settings.py`:
 JSON_EDITOR_ACE_OPTIONS_JS = "[your_ace_options_file].js"
 ```
 
+### Per-field customization
+You can also override JSONEditor and Ace initialization on a per-field basis. To do this, pass the
+desired `init_options` and/or `ace_option` to the widget's initializer. For example, let's
+say you want to make a certain field read-only:
+
+```python
+from django.contrib import admin
+from django.db.models.fields.json import JSONField
+from jsoneditor.forms import JSONEditor
+
+
+class MyAdmin(admin.ModelAdmin):
+    formfield_overrides = {
+        JSONField: {
+            "widget": JSONEditor(
+                init_options={"mode": "view", "modes": ["view", "code", "tree"]},
+                ace_options={"readOnly": True},
+            )
+        }
+    }
+```
+
+These values will override any project-level options in the custom javascript files described above.
+
 ## Use
 
 You can use the JSONEditor widget for fields in selected Admin classes like:
 
 admin.py:
 ```python
-from json_field import JSONField
+from django.contrib import admin
+from django.db.models.fields.json import JSONField
 from jsoneditor.forms import JSONEditor
+
+
 class MyAdmin(admin.ModelAdmin):
     formfield_overrides = {
-        JSONField:{ 'widget':JSONEditor },
+        JSONField: {'widget': JSONEditor},
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Sample views:
 
 <img alt="json editor" src="https://raw.github.com/josdejong/jsoneditor/master/misc/jsoneditor.png">
 
-*Don't mismatch this repo with https://github.com/skyhood/django-jsoneditor*
-
 ## Installation
 
 ### Latest version from the GIT repository::
@@ -29,9 +27,9 @@ Note that you should use one of original JSONField packages to provide the JSONF
 You **should** append `jsoneditor` into the `INSTALLED_APPS` of your `settings.py` file:
 ```python
 INSTALLED_APPS = (
-    ...
+    # ...
     'jsoneditor',
-    ...
+    # ...
 )
 ```
 
@@ -59,7 +57,7 @@ file.
 **Note** that the django original static file subsystem is used to
 refer to the init file.
 
-For example, let's your project has a `myapp` application,
+For example, let's say your project has a `myapp` application,
 and you would like to init all available modes of the JSONEditor
 instead of two allowed by default.
 
@@ -77,7 +75,7 @@ JSON_EDITOR_INIT_JS = "jsoneditor-init.js"
 ```
 (**note** that the static file subsystem refers to static files without `static` prefix)
 
-Also you can extend the `JSON_EDITOR_INIT_JS` file as you wish, it will be used on every
+You can extend the `JSON_EDITOR_INIT_JS` file as you wish; it will be used on every
 page where the `JSONEditor` widget is used just before the `django-jsonfield.js` file.
 
 ### Custom Ace initialization
@@ -91,6 +89,42 @@ pointed to by adding the following line to your `settings.py`:
 JSON_EDITOR_ACE_OPTIONS_JS = "[your_ace_options_file].js"
 ```
 
+### Per-field customization
+You can also override JSONEditor and Ace initialization on a per-field basis. To do this, create a
+javascript file with an object named `django_jsoneditor_init_override` and/or
+`django_jsoneditor_ace_options_override`, and create a subclass of `JSONEditor`. For example, let's
+say you want to make a certain field read-only.
+
+* create a file `myapp/static/jsoneditor-init-readonly.js` 
+
+```javascript
+django_jsoneditor_init_override = {
+    mode: 'view',
+    modes: ['view', 'code']
+}
+
+django_jsoneditor_ace_options_override = {
+    readOnly: true
+}
+```
+
+* Subclass `JSONEditor` and use your custom class as the field's widget
+
+```python
+from jsoneditor.forms import JSONEditor
+
+
+class ViewOnlyJSONEditor(JSONEditor):
+    class Media:
+        js = ('jsoneditor-init-viewonly.js',)
+
+
+class MyAdmin(admin.ModelAdmin):
+    formfield_overrides = {
+        JSONField: {'widget': ViewOnlyJSONEditor},
+    }
+```
+
 ## Use
 
 You can use the JSONEditor widget for fields in selected Admin classes like:
@@ -99,9 +133,11 @@ admin.py:
 ```python
 from json_field import JSONField
 from jsoneditor.forms import JSONEditor
+
+
 class MyAdmin(admin.ModelAdmin):
     formfield_overrides = {
-        JSONField:{ 'widget':JSONEditor },
+        JSONField: {'widget': JSONEditor},
     }
 ```
 

--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,6 @@ Sample views:
 
 .. image:: https://raw.github.com/josdejong/jsoneditor/master/misc/jsoneditor.png
 
-*Don't mismatch this project with* https://github.com/skyhood/django-jsoneditor
-
 Installation
 ------------
 Latest version from the GIT repository::

--- a/jsoneditor/forms.py
+++ b/jsoneditor/forms.py
@@ -47,10 +47,14 @@ class JSONEditor(Textarea):
 
     def __init__(self, *args, **kwargs):
         self.jsonschema = kwargs.pop('jsonschema', None)
+        self.init_options = kwargs.pop('init_options', None)
+        self.ace_options = kwargs.pop('ace_options', None)
         super().__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None, renderer=None):
         attrs['jsonschema'] = json.dumps(self.jsonschema)
+        attrs['init_options'] = json.dumps(self.init_options)
+        attrs['ace_options'] = json.dumps(self.ace_options)
 
         if not isinstance(value, basestring):
             value = json.dumps(value)

--- a/jsoneditor/static/django-jsoneditor/django-jsoneditor.js
+++ b/jsoneditor/static/django-jsoneditor/django-jsoneditor.js
@@ -26,7 +26,11 @@ django.jQuery(function () {
             }
             $f.parent().append($nxt);
             var fnc = function (f, nxt, value) {
-                var initOptions = Object.assign({}, django_jsoneditor_init);
+                try {
+                    var initOptions = Object.assign({}, django_jsoneditor_init_override);
+                } catch(error) {
+                    var initOptions = Object.assign({}, django_jsoneditor_init);
+                }
                 initOptions['schema'] = jsonschema;
 
                 var editor = new jsoneditor.JSONEditor(nxt, Object.assign({
@@ -36,7 +40,11 @@ django.jQuery(function () {
                     // If switching to code mode, properly initialize with ace options
                     onModeChange: function(endMode, startMode) {
                         if (endMode == 'code') {
-                            editor.aceEditor.setOptions(django_jsoneditor_ace_options);
+                            try {
+                                editor.aceEditor.setOptions(django_jsoneditor_ace_options_override);
+                            } catch (error) {
+                                editor.aceEditor.setOptions(django_jsoneditor_ace_options);
+                            }
                         }
                     },
                     onEditable: function() {

--- a/jsoneditor/static/django-jsoneditor/django-jsoneditor.js
+++ b/jsoneditor/static/django-jsoneditor/django-jsoneditor.js
@@ -17,6 +17,8 @@ django.jQuery(function () {
             var style = $f.attr("style");
             var disabled = $f.is(':disabled');
             var jsonschema = JSON.parse($f.attr("jsonschema"));
+            var initOverrides = JSON.parse($f.attr("init_options"));
+            var aceOverrides = JSON.parse($f.attr("ace_options"));
 
             $nxt.detach();
             if (style) {
@@ -26,7 +28,7 @@ django.jQuery(function () {
             }
             $f.parent().append($nxt);
             var fnc = function (f, nxt, value) {
-                var initOptions = Object.assign({}, django_jsoneditor_init);
+                var initOptions = Object.assign({}, initOverrides ? initOverrides : django_jsoneditor_init);
                 initOptions['schema'] = jsonschema;
 
                 var editor = new jsoneditor.JSONEditor(nxt, Object.assign({
@@ -36,7 +38,7 @@ django.jQuery(function () {
                     // If switching to code mode, properly initialize with ace options
                     onModeChange: function(endMode, startMode) {
                         if (endMode == 'code') {
-                            editor.aceEditor.setOptions(django_jsoneditor_ace_options);
+                            editor.aceEditor.setOptions(aceOverrides ? aceOverrides : django_jsoneditor_ace_options);
                         }
                     },
                     onEditable: function() {


### PR DESCRIPTION
Fixes #65

This PR allows overriding either the default or project-level `django_jsoneditor_init` and/or `django_jsoneditor_ace_options` on a per-field basis.