### PR TITLE
use Django serializer for dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,18 @@ class MyAdmin(admin.ModelAdmin):
         JSONField: {'widget': JSONEditor(attrs={'style': 'width: 620px;'})}
     }
 ```
+## Custom Encoders
+
+There are situations where you may prefer to use a custom [JSONEncoder](https://docs.python.org/3/library/json.html#json.JSONEncoder) class. For example, you may want to use Django's [DjangoJSONEncoder](https://docs.djangoproject.com/en/4.1/topics/serialization/#djangojsonencoder) to handle timestamps in a Django-friendly way. You can do this by passing the `encoder` param as an initialization argument.
+
+``` python
+from django.core.serializers.json import DjangoJSONEncoder
+
+class MyAdmin(admin.ModelAdmin):
+    formfield_overrides = {
+        JSONField: {'widget': JSONEditor(encoder=DjangoJSONEncoder)} # will now encode/decode python datetime and timestamp objects!
+    }
+```
 
 ## Collecting bounties
 

--- a/jsoneditor/forms.py
+++ b/jsoneditor/forms.py
@@ -48,13 +48,13 @@ class JSONEditor(Textarea):
 
     def __init__(self, *args, **kwargs):
         self.jsonschema = kwargs.pop('jsonschema', None)
+        self.encoder = kwargs.pop("encoder", None)
         super().__init__(*args, **kwargs)
 
     def render(self, name, value, attrs=None, renderer=None):
         attrs['jsonschema'] = json.dumps(self.jsonschema)
-
         if not isinstance(value, basestring):
-            value = json.dumps(value, cls=DjangoJSONEncoder)
+            value = json.dumps(value, cls=self.encoder)
 
         input_attrs = {'hidden': True}
         input_attrs.update(attrs)

--- a/jsoneditor/forms.py
+++ b/jsoneditor/forms.py
@@ -5,6 +5,7 @@ import django
 from django.conf import settings
 from django.forms.widgets import Textarea
 from django.utils.safestring import mark_safe
+from django.core.serializers.json import DjangoJSONEncoder
 
 
 try:
@@ -53,7 +54,7 @@ class JSONEditor(Textarea):
         attrs['jsonschema'] = json.dumps(self.jsonschema)
 
         if not isinstance(value, basestring):
-            value = json.dumps(value)
+            value = json.dumps(value, cls=DjangoJSONEncoder)
 
         input_attrs = {'hidden': True}
         input_attrs.update(attrs)


### PR DESCRIPTION
This helps to handle things like date objects that will cause the dreaded "datetime.date not JSON serializable" error. 

I tried to get the test sites working to use existing tests, but I couldn't get the requirements to play nice and I eventually just plugged it into my downstream project. 
Before: 
![Screenshot from 2022-09-08 10-48-48](https://user-images.githubusercontent.com/6440476/189153657-69104d6f-82f2-4ad1-ac83-321fee1decc1.png)

After: 
![Screenshot from 2022-09-08 10-44-57](https://user-images.githubusercontent.com/6440476/189152882-d5548980-dc41-4dd0-977c-0e7942885bb9.png)
